### PR TITLE
Adding delay to responses

### DIFF
--- a/docs/REQUEST_MATCHING.md
+++ b/docs/REQUEST_MATCHING.md
@@ -6,6 +6,7 @@ The current mock middleware supports matching of request to stubs using the foll
 * Query parameters
 * Headers
 * Request body
+* Adding delay
 
 The following sections describes each type of matching strategy in detail.
 
@@ -164,5 +165,19 @@ Request body can be matched by [JSONPath expresion](https://github.com/dchester/
     "..."
   },
   "..."
+}
+```
+
+## Adding delay
+
+All responses can be delayed aggregating *delay* attribute into json request match. Value must be in milliseconds and greater than 0.
+
+Request that respond in 1500 milliseconds or 1,5 seconds.
+```json
+{
+  "request": {
+     "..."
+  },
+  "delay" : 1500
 }
 ```

--- a/lib/rest-mock-middleware.js
+++ b/lib/rest-mock-middleware.js
@@ -7,6 +7,9 @@ const requestMachings = require('./request-matching/index');
 
 const mockIdentifier = "[Mock]";
 
+const isNumber = function(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
 
 const mocksMiddleware = function(mocksConfiguration) {
 
@@ -132,11 +135,22 @@ const mocksMiddleware = function(mocksConfiguration) {
               body += '\n' + e.message;
             }
           }
-          res.send(body);
-
+          if(route.delay && isNumber(route.delay) && route.delay > 0){
+              setTimeout(function onDelayingResponse(){
+                res.send(body);
+              }, parseInt(route.delay, 10));
+          }else{
+              res.send(body);
+          }
         } else if (route.response.jsonBody) {
           body = route.response.jsonBody;
-          res.send(body);
+          if(route.delay && isNumber(route.delay) && route.delay > 0){
+              setTimeout(function onDelayingResponse(){
+                res.send(body);
+              }, parseInt(route.delay, 10));
+          }else{
+              res.send(body);
+          }
         }
         console.log(mockIdentifier + " " + req.method + " " + req.originalUrl + " -> "); // eslint-disable-line no-console
         // eslint-disable-next-line no-console


### PR DESCRIPTION
All responses can be delayed aggregating *delay* attribute into json request match. For example, a mock that answers in 1,5 seconds:

```json
{
  "request": {
     "..."
  },
  "delay" : 1500
}
```